### PR TITLE
Corrected redirect method calling object

### DIFF
--- a/lib/controllers/DerbyRouteController.js
+++ b/lib/controllers/DerbyRouteController.js
@@ -45,7 +45,7 @@ DerbyRouteController.prototype.redirect = function(name, options){
   var router = this._router;
   var path = router.pathFor.apply(router, args);
 
-  this.app.page.redirect(path);
+  this.page.redirect(path);
 };
 
 DerbyRouteController.prototype.next = function(err){


### PR DESCRIPTION
Changed `this.app.page.redirect` to `this.page.redirect`, because the first one was causing the error `TypeError: Cannot call method 'redirect' of null`.
